### PR TITLE
R4.2: fix fedora-39-minimal config

### DIFF
--- a/R4.2/qubes-os-r4.2-templates-itl.yml
+++ b/R4.2/qubes-os-r4.2-templates-itl.yml
@@ -90,6 +90,7 @@ templates:
   - fedora-39-minimal:
       dist: fc39
       timeout: 7200
+      flavor: minimal
   - fedora-40:
       dist: fc40
       options:
@@ -104,7 +105,6 @@ templates:
   - fedora-40-minimal:
       dist: fc40
       timeout: 7200
-      flavor: minimal
       flavor: minimal
   - debian-11:
       dist: bullseye


### PR DESCRIPTION
Fixes QubesOS/qubes-issues#9043
Fixes b0a7e2f
This fixes Fedora 39 minimal template size.