### PR TITLE
Install kernel in Whonix templates

### DIFF
--- a/R4.2/qubes-os-r4.2-templates-community.yml
+++ b/R4.2/qubes-os-r4.2-templates-community.yml
@@ -75,6 +75,7 @@ templates:
       options:
         - minimal
         - no-recommends
+        - install-kernel
       timeout: 5400
   - whonix-workstation-17:
       dist: bookworm
@@ -82,6 +83,7 @@ templates:
       options:
         - minimal
         - no-recommends
+        - install-kernel
       timeout: 5400
   - centos-stream-8:
       dist: centos-stream8

--- a/R4.3/qubes-os-r4.3-templates-community.yml
+++ b/R4.3/qubes-os-r4.3-templates-community.yml
@@ -61,6 +61,7 @@ templates:
       options:
         - minimal
         - no-recommends
+        - install-kernel
       timeout: 5400
   - whonix-workstation-17:
       dist: bookworm
@@ -68,6 +69,7 @@ templates:
       options:
         - minimal
         - no-recommends
+        - install-kernel
       timeout: 5400
   - centos-stream-8:
       dist: centos-stream8


### PR DESCRIPTION
Whonix is going to switch to in-vm kernel, which require the kernel to
be installed in the template. Since, Whonix is based on minimal
template, it isn't the case normally. Add "install-kernel" option to
install it anyway.

QubesOS/qubes-issues#9570

This depends on https://github.com/QubesOS/qubes-builder-debian/pull/87