### PR TITLE
devel: Disable notifications for referenced issues

### DIFF
--- a/Rdevel/qubes-os-devel-debian.yml
+++ b/Rdevel/qubes-os-devel-debian.yml
@@ -33,6 +33,7 @@ repository-upload-remote-host:
   deb: 'deb.qubes-os.org:/pub/qubes/repo/deb/devel'
 
 github:
+  message-templates-dir: /home/user/qubes-builderv2-github/templates-status-only
   maintainers:
     # marmarek
     '17B7CC1986BD3D28C41475B6846D6B709C6E2E7F':

--- a/Rdevel/qubes-os-devel-fedora.yml
+++ b/Rdevel/qubes-os-devel-fedora.yml
@@ -35,6 +35,7 @@ repository-upload-remote-host:
   rpm: 'yum.qubes-os.org:/pub/qubes/repo/yum/devel'
 
 github:
+  message-templates-dir: /home/user/qubes-builderv2-github/templates-status-only
   maintainers:
     # marmarek
     '17B7CC1986BD3D28C41475B6846D6B709C6E2E7F':

--- a/Rdevel/qubes-os-devel-host.yml
+++ b/Rdevel/qubes-os-devel-host.yml
@@ -47,6 +47,7 @@ repository-upload-remote-host:
   rpm: 'yum.qubes-os.org:/pub/qubes/repo/yum/devel'
 
 github:
+  message-templates-dir: /home/user/qubes-builderv2-github/templates-status-only
   maintainers:
     # marmarek
     '17B7CC1986BD3D28C41475B6846D6B709C6E2E7F':


### PR DESCRIPTION
This isn't helpful for users, as those packages aren't really
"released".

QubesOS/qubes-issues#10478

This requires https://github.com/QubesOS/qubes-builderv2-github/pull/31