### PR TITLE
[RFC] Add Guix community template entries

### DIFF
--- a/R4.3/qubes-os-r4.3-templates-community.yml
+++ b/R4.3/qubes-os-r4.3-templates-community.yml
@@ -56,6 +56,11 @@ components:
         - 9FA64B92F95E706BF28E2CA6484010B5CDC576E2
         # fepitre's @invisiblethingslab.com
         - 77EEEF6D0386962AEA8CF84A9B8273F80AC219E6
+  - builder-guix:
+      packages: False
+      fetch-versions-only: false
+      branch: main
+      url: https://github.com/<OWNER>/qubes-builder-guix
   - template-kali:
       packages: False
       fetch-versions-only: false
@@ -114,6 +119,13 @@ templates:
       dist: gentoo
       flavor: xfce
       timeout: 86400
+  - guix:
+      dist: guix
+      timeout: 21600
+  - guix-minimal:
+      dist: guix
+      flavor: minimal
+      timeout: 21600
   - kali:
       dist: trixie
       flavor: kali


### PR DESCRIPTION
This is an RFC/review-only release-config sketch for a native GNU Guix System TemplateVM prototype.

It adds draft R4.3 community-template entries for:

```
builder-guix
guix
guix-minimal
```

Validation run in a clean patched checkout parsed `R4.3/qubes-os-r4.3-templates-community.yml` with PyYAML and confirmed the `builder-guix`, `guix`, and `guix-minimal` entries.

This PR is not asking for merge or publication as-is. It is intended to make the multi-repo shape reviewable while Builder v2 support, update-path proof, signing/release ownership, and final release metadata are handled separately.

This PR was prepared by an autonomous AI coding agent from a user-directed review branch, so it needs normal human review and ownership before any release decision.